### PR TITLE
feat: Add ability to use arbitrary headers for actions

### DIFF
--- a/listener_rule/listener_rule.tf
+++ b/listener_rule/listener_rule.tf
@@ -78,8 +78,8 @@ resource "aws_lb_listener_rule" "this" {
         for_each = try([condition.value.other_header], [])
 
         content {
-          http_header_name = condition.http_header_name
-          values          = condition.values
+          http_header_name = other_header.http_header_name
+          values           = other_header.values
         }
       }
     }

--- a/listener_rule/listener_rule.tf
+++ b/listener_rule/listener_rule.tf
@@ -71,6 +71,21 @@ resource "aws_lb_listener_rule" "this" {
   }
 
   dynamic "condition" {
+    for_each = [for condition in each.value.conditions : condition if contains(keys(condition), "other_header")]
+    content {
+
+      dynamic "http_header" {
+        for_each = try([condition.value.other_header], [])
+
+        content {
+          http_header_name = condition.http_header_name
+          values          = condition.values
+        }
+      }
+    }
+  }
+
+  dynamic "condition" {
     for_each = [for condition in each.value.conditions : condition if contains(keys(condition), "path_pattern")]
 
     content {

--- a/listener_rule/listener_rule.tf
+++ b/listener_rule/listener_rule.tf
@@ -78,8 +78,8 @@ resource "aws_lb_listener_rule" "this" {
         for_each = try([condition.value.other_header], [])
 
         content {
-          http_header_name = other_header.http_header_name
-          values           = other_header.values
+          http_header_name = other_header.value.http_header_name
+          values           = other_header.value.values
         }
       }
     }

--- a/listener_rule/listener_rule.tf
+++ b/listener_rule/listener_rule.tf
@@ -78,8 +78,8 @@ resource "aws_lb_listener_rule" "this" {
         for_each = try([condition.value.other_header], [])
 
         content {
-          http_header_name = other_header.value.http_header_name
-          values           = other_header.value.values
+          http_header_name = http_header.value.http_header_name
+          values           = http_header.value.values
         }
       }
     }


### PR DESCRIPTION
Provides functionality to use arbitrary HTTP headers as `conditions` in `aws_lb_listener_rule` terraform resources